### PR TITLE
fix: enable mobile nav links

### DIFF
--- a/src/lib/components/header_nav.svelte
+++ b/src/lib/components/header_nav.svelte
@@ -7,12 +7,11 @@
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-<!-- svelte-ignore a11y-label-has-associated-control -->
 <!-- reference: https://github.com/saadeghi/daisyui/issues/1285 -->
 <div class='dropdown lg:hidden'>
-  <label class='btn btn-square btn-ghost' tabindex='0'>
+  <button class='btn btn-square btn-ghost'>
     <span class='i-heroicons-outline-menu-alt-1' />
-  </label>
+  </button>
   <ul
     class='menu menu-compact dropdown-content bg-base-100 text-base-content shadow-lg rounded-box min-w-max max-w-52 p-2'
     class:hidden={!pin}

--- a/src/lib/components/header_nav.svelte
+++ b/src/lib/components/header_nav.svelte
@@ -7,15 +7,15 @@
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+<!-- svelte-ignore a11y-label-has-associated-control -->
 <!-- reference: https://github.com/saadeghi/daisyui/issues/1285 -->
 <div class='dropdown lg:hidden'>
-  <label class='btn btn-square btn-ghost' for='navbar-dropdown' tabindex='0'>
+  <label class='btn btn-square btn-ghost' tabindex='0'>
     <span class='i-heroicons-outline-menu-alt-1' />
   </label>
   <ul
     class='menu menu-compact dropdown-content bg-base-100 text-base-content shadow-lg rounded-box min-w-max max-w-52 p-2'
     class:hidden={!pin}
-    id='navbar-dropdown'
     tabindex='0'>
     {#each nav as { children, link, text }}
       {#if link && !children}


### PR DESCRIPTION
## Summary
- remove invalid label association that blocked nav links on iOS
- silence accessibility warning for unbound label

## Testing
- `pnpm exec eslint --flag unstable_ts_config src/lib/components/header_nav.svelte`
- `pnpm build` *(fails: EEXIST: file already exists, mkdir 'src/routes/blog')*

------
https://chatgpt.com/codex/tasks/task_e_68a0e97d35948328a14bbe14a4fd4c50