### PR TITLE
Expand sitemap coverage to all pages

### DIFF
--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -3,8 +3,37 @@ import { genPosts } from '$lib/utils/posts'
 
 import type { RequestHandler } from './$types'
 
-const render = (): string =>
-  `<?xml version='1.0' encoding='utf-8'?>
+const pageRoutes = Object.keys(import.meta.glob('/src/routes/**/+page.svelte', { eager: true }))
+  .map(path => path.replace('/src/routes', '').replace(/\/\+page\.svelte$/, '') || '/')
+  .filter(route => route !== '/')
+
+const slideRoutes = Object.keys(import.meta.glob('/urara/slides/**/index.html', { eager: true }))
+  .map(path => path.replace('/urara', '').replace(/\/index\.html$/, ''))
+
+const render = (): string => {
+  const postEntries = genPosts()
+    .map(
+      post => `
+        <url>
+            <loc>${site.protocol + site.domain + post.path}</loc>
+            <lastmod>${new Date(post.updated ?? post.published ?? post.created).toISOString()}</lastmod>
+            <priority>0.5</priority>
+        </url>`,
+    )
+    .join('')
+
+  const staticEntries = [...pageRoutes, ...slideRoutes]
+    .sort()
+    .map(
+      route => `
+        <url>
+            <loc>${site.protocol + site.domain + route}</loc>
+            <priority>0.7</priority>
+        </url>`,
+    )
+    .join('')
+
+  return `<?xml version='1.0' encoding='utf-8'?>
   <urlset
     xmlns="https://www.sitemaps.org/schemas/sitemap/0.9"
     xmlns:xhtml="https://www.w3.org/1999/xhtml"
@@ -14,18 +43,9 @@ const render = (): string =>
     xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
     <url>
       <loc>${site.protocol + site.domain}</loc>
-    </url>
-    ${genPosts()
-        .map(
-          post => `
-        <url>
-            <loc>${site.protocol + site.domain + post.path}</loc>
-            <lastmod>${new Date(post.updated ?? post.published ?? post.created).toISOString()}</lastmod>
-            <priority>0.5</priority>
-        </url>`,
-        )
-        .join('')}
+    </url>${staticEntries}${postEntries}
   </urlset>`.trim()
+}
 
 export const prerender = true
 export const trailingSlash = 'never'

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -5,8 +5,6 @@ import type { RequestHandler } from './$types'
 
 const pageRoutes = Object.keys(import.meta.glob('/src/routes/**/+page.svelte', { eager: true }))
   .map(path => path.replace('/src/routes', '').replace(/\/\+page\.svelte$/, '') || '/')
-  .filter(route => route !== '/')
-
 const slideRoutes = Object.keys(import.meta.glob('/urara/slides/**/index.html', { eager: true }))
   .map(path => path.replace('/urara', '').replace(/\/index\.html$/, ''))
 


### PR DESCRIPTION
## Summary
- include statically routed Svelte pages and slide decks in the generated sitemap
- retain post metadata while appending static routes so every page is discoverable

## Testing
- pnpm lint *(fails: pre-existing style violations in `urara/slides/metrics-visualization-for-realtime-services/libs`)*

------
https://chatgpt.com/codex/tasks/task_e_68d963ba82748328878b9df3aef30fc9